### PR TITLE
:ambulance: :green_heart: Unshallow git repo in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Fetch history
+        run: git fetch --prune --unshallow
+        
       - name: Configure Git
         run: |
           git config user.name "$GITHUB_ACTOR"


### PR DESCRIPTION
Needed so the releaser can detect changes.