### PR TITLE
Refactor ingress.yaml to match helm create

### DIFF
--- a/charts/timed/Chart.yaml
+++ b/charts/timed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timed
 type: application
 description: Chart for Timed application
-version: 0.2.0
+version: 0.2.1
 appVersion: v0.12.1
 home: https://github.com/adfinis-sygroup/timed-frontend
 keywords:

--- a/charts/timed/templates/ingress.yaml
+++ b/charts/timed/templates/ingress.yaml
@@ -6,10 +6,10 @@ metadata:
   labels:
     {{- include "timed.labels" . | nindent 4 }}
     app.kubernetes.io/component: frontend
-{{- with .Values.ingress.annotations }}
+  {{- with .Values.ingress.annotations }}
   annotations:
-{{- toYaml . | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   rules:
     {{- range $host := .Values.ingress.hosts }}

--- a/charts/timed/values.yaml
+++ b/charts/timed/values.yaml
@@ -89,18 +89,16 @@ frontend:
     successThreshold: 1
 
 ingress:
-  enabled: true
-  # Used to create an Ingress record.
-  hosts:
-    - chart-example.local
+  enabled: false
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  tls:
-    # Secrets must be manually created in the namespace.
-    # - secretName: chart-example-tls
-    #   hosts:
-    #     - chart-example.local
+  hosts:
+    - chart-example.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
 
 postgresql:
   enabled: true


### PR DESCRIPTION
This refactor makes the ingress look a bit more like what `helm create` would do. I'm mostly touching this since specifying `ingress.annotations` was leading to a `error converting YAML to JSON: yaml: line 14: mapping values are not allowed in this context` error.

While I was at fixing that I also disabled ingress by default so you have to explicitly configure it like most charts would make you to.

Fixes #12.
